### PR TITLE
enable mfa token cache for linux

### DIFF
--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -115,8 +115,10 @@ class SnowflakeCredentials(Credentials):
                     )
 
                 result['token'] = token
-            # enable the token cache
+            # enable id token cache for linux
             result['client_store_temporary_credential'] = True
+            # enable mfa token cache for linux
+            result['client_request_mfa_token'] = True
         result['private_key'] = self._get_private_key()
         return result
 


### PR DESCRIPTION
enables mfa token caching for linux when using the `username_password_mfa` authenticator

resolves #64

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.